### PR TITLE
Made a super tiny change to allow configuring the dps id

### DIFF
--- a/localtuya/light.py
+++ b/localtuya/light.py
@@ -32,7 +32,7 @@ from homeassistant.util import color as colorutil
 import socket
 
 REQUIREMENTS = ['pytuya==7.0.4']
-
+CONF_ID = 'dps_id'
 CONF_DEVICE_ID = 'device_id'
 CONF_LOCAL_KEY = 'local_key'
 CONF_PROTOCOL_VERSION = 'protocol_version'

--- a/localtuya/switch.py
+++ b/localtuya/switch.py
@@ -23,6 +23,7 @@ log = logging.getLogger(__name__)
 
 REQUIREMENTS = ['pytuya==7.0.4']
 
+CONF_ID = 'dps_id'
 CONF_DEVICE_ID = 'device_id'
 CONF_LOCAL_KEY = 'local_key'
 CONF_PROTOCOL_VERSION = 'protocol_version'


### PR DESCRIPTION
I needed this tiny change to define the IDs for the light switch on my tuya enabled ceiling fan:

`{
  dps: {
    '1': false,
    '3': '3',
    '4': 'reverse',
    '9': true,
    '102': 'normal',
    '103': 'off'
  }
}`

dps ID 1: turns the fan on and off
dps ID 3: sets the fan speed (1-6)
dps ID 4: rotation direction of the fan
dps ID 9: This is the light switch
dps ID 102: Couple of pre-defined rotation modes
dps ID 103: hour based timer 

This PR is the beginning the start of adjusting this great fork for usage with a fan. 